### PR TITLE
Rewrite to leverage treesitter more, allow `name` arg

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,7 +12,7 @@ const [anchor, setAnchor] = useState(null)
 
 ## Features
 
-- Leverages Neovim's Treesitter integration (requires neovim >= 0.5.0).
+- Leverages [Treesitter](https://tree-sitter.github.io/tree-sitter/) (requires [neovim](https://neovim.io/) >= 0.5.0).
 - Supports Javascript and Typescript files.
 - Supports [React](https://reactjs.org/) and [Solid](https://www.solidjs.com/) state hooks.
 
@@ -33,7 +33,7 @@ use { "olrtg/nvim-rename-state" }
 [vim-plug](https://github.com/junegunn/vim-plug)
 
 ```vim
-Plug 'catppuccin/nvim'
+Plug 'olrtg/nvim-rename-state'
 ```
 
 ## Usage

--- a/README.md
+++ b/README.md
@@ -6,48 +6,50 @@ Rename the getter and a setter of a state hook in react/solidjs at the same time
 // Initial code
 const [anchorEl, setAnchorEl] = useState(null)
 
-// If you rename `anchorEl` to `anchor`
-// If you rename `setAnchorEl` to `setAnchor`
+// After renaming with `:RenameState` or `:RenameState anchor`
 const [anchor, setAnchor] = useState(null)
 ```
 
-## Getting started
+## Features
 
-### Prerequisites
+- Leverages Neovim's Treesitter integration (requires neovim >= 0.5.0).
+- Supports Javascript and Typescript files.
+- Supports [React](https://reactjs.org/) and [Solid](https://www.solidjs.com/) state hooks.
 
-To use `nvim-rename-state`, since it makes use of [Neovim](https://github.com/neovim/neovim)'s built-in LSP, you will need to have installed [Neovim v0.5.0](https://github.com/neovim/neovim/releases/tag/v0.5.0) or [newer](https://github.com/neovim/neovim/releases/latest) and [treesitter](https://github.com/nvim-treesitter/nvim-treesitter).
+## Installation
 
-### Installation
-
-Using [packer.nvim](https://github.com/wbthomason/packer.nvim)
-
-```lua
-use {
-  'olrtg/nvim-rename-state',
-  branch = 'main'
-}
-```
-
-Using [vim-plug](https://github.com/junegunn/vim-plug):
-
-```viml
-Plug 'olrtg/nvim-rename-state', { 'branch': 'main' }
-```
-
-### Loading the plugin
-
-Either in any lua file that gets loaded:
+[lazy.nvim](https://github.com/folke/lazy.nvim)
 
 ```lua
-require'nvim-rename-state'.setup{}
+{ "olrtg/nvim-rename-state" }
 ```
 
-Or in `init.vim`
+[packer.nvim](https://github.com/wbthomason/packer.nvim)
 
-```viml
-lua require('nvim-rename-state')
+```lua
+use { "olrtg/nvim-rename-state" }
+```
+
+[vim-plug](https://github.com/junegunn/vim-plug)
+
+```vim
+Plug 'catppuccin/nvim'
+```
+
+## Usage
+
+Put your cursor in the row of the defined `useState` or `createSignal` hook and use:
+
+```vim
+:RenameState
+```
+
+Or if you want to pass the new name for the hook in advance:
+
+```vim
+:RenameState <new_name>
 ```
 
 ## Contributing
 
-All contributions are welcome! Just open a pull request or an issue.
+All contributions are welcomed! Just open a pull request or an issue.

--- a/lua/nvim-rename-state/init.lua
+++ b/lua/nvim-rename-state/init.lua
@@ -1,7 +1,8 @@
 local M = {}
 
+-- @deprecated setup function is no longer needed
 M.setup = function()
-  vim.api.nvim_create_user_command("RenameState", M.rename_state, { nargs = "?" })
+  vim.notify("nvim-rename-state: setup function is now deprecated since is no longer needed", vim.log.levels.WARN)
 end
 
 M.rename_state = function(command_obj)

--- a/lua/nvim-rename-state/utils.lua
+++ b/lua/nvim-rename-state/utils.lua
@@ -1,19 +1,7 @@
 local M = {}
 
-M.startswith = function(text, prefix)
-  return text:find(prefix, 1, true) == 1
-end
-
-M.chopstart = function(text, prefix)
-  return string.sub(text, string.len(prefix) + 1, string.len(text))
-end
-
 M.upperfirst = function(text)
   return string.sub(text, 1, 1):upper() .. string.sub(text, 2)
-end
-
-M.lowerfirst = function(text)
-  return string.sub(text, 1, 1):lower() .. string.sub(text, 2)
 end
 
 return M

--- a/plugin/nvim-rename-state.lua
+++ b/plugin/nvim-rename-state.lua
@@ -1,0 +1,1 @@
+vim.api.nvim_create_user_command("RenameState", require("nvim-rename-state").rename_state, { nargs = "?" })


### PR DESCRIPTION
This is a full rewrite of the plugin to leverage treesitter a lot more. The plugin seems more reliable than ever (better matching) and with this new architecture I've removed a lot of edge cases.

A visible benefit for the users is that now they can use the `:RenameState` command in any part of the current row (before you needed to be on top of the getter or the setter).

Another new feature that I've introduced with this rewrite is allowing the new name of the hook as an argument of the command (`:RenameState <new_name>`). Fixes #6 

PD: After updating the docs I'll merge this.